### PR TITLE
Terminate an Abonnement

### DIFF
--- a/src/app/presentation/abonnement/abonnement.component.html
+++ b/src/app/presentation/abonnement/abonnement.component.html
@@ -16,7 +16,7 @@
     </button>
     <button mat-mini-fab
             color="warn"
-            [disabled]="abonnement.status !== abonnementStatus.OPGEZEGD"
+            [disabled]="abonnement.status == abonnementStatus.OPGEZEGD"
             (click)="onTerminate()"
             matTooltip="Terminate subscription">
       <mat-icon>delete</mat-icon>


### PR DESCRIPTION
De knop om een abonnement op te zeggen moet alleen "disabled" zijn als het abonnement al is opgezegd, en moet dus enabled zijn als het abonnement nog niet is opgezegd. 

De terminate knop is nu namelijk alleen beschikbaar als de status in de database al op "opgezegd" staat. 
Terwijl dit juist andersom hoort te zijn. Beschikbaar als de status van het abonnement nog niet is opgezegd. 