### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,11 +319,11 @@ It will expect a response containing an array of all Abonnees:
 ]
 ```
 
-##### Sare an Abonnement with an Abonnee
+##### Share an Abonnement with an Abonnee
 
 To share an Abonnement with an Abonnee:
 ```
-url:              /abonnee/:id
+url:              /abonnees/:id
 method:           POST
 query parameter:  token
 ```


### PR DESCRIPTION
fixed a typo in 'share an abonnement'.
changed url from /abonnee to /abonnees (same endpoint as for get all abonnees)